### PR TITLE
Allow custom port mappings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,7 @@ LOG_LEVEL=INFO
 
 # Python Path (adjust if needed)
 PYTHON_PATH=python3
+
+# Port Configuration
+# APP_PORT=8000
+# POSTGRES_PORT=5432

--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -20,6 +20,52 @@ This guide explains how to run BerryRAG with Docker and PostgreSQL with pgvector
    docker-compose up --build
    ```
 
+## Port Configuration
+
+You can customize the host ports for both services using environment variables:
+
+### Default Ports
+
+- **Application**: `localhost:8000`
+- **PostgreSQL**: `localhost:5432`
+
+### Custom Ports via Environment Variables
+
+1. **Set in .env file**:
+
+   ```bash
+   # Edit .env file
+   APP_PORT=8084
+   POSTGRES_PORT=5435
+
+   # Start services
+   docker-compose up --build
+   ```
+
+2. **Set via command line**:
+
+   ```bash
+   # Use custom ports for this session
+   APP_PORT=8084 POSTGRES_PORT=5435 docker-compose up --build
+   ```
+
+3. **Access services with custom ports**:
+   - Application: `http://localhost:8084`
+   - PostgreSQL: `localhost:5435`
+
+### Local Development with Custom Ports
+
+When running the application locally with custom PostgreSQL port:
+
+```bash
+# Start only PostgreSQL on custom port
+POSTGRES_PORT=5435 docker-compose up postgres
+
+# Connect locally with custom port
+export DATABASE_URL="postgresql://berryrag:berryrag_password@localhost:5435/berryrag"
+python src/rag_system_pgvector.py stats
+```
+
 ## Architecture
 
 - **PostgreSQL with pgvector**: Vector database for embeddings
@@ -98,6 +144,8 @@ context = rag.get_context_for_query("your query")
 | `CHUNK_OVERLAP`        | `50`                                                             | Overlap between chunks                              |
 | `DEFAULT_TOP_K`        | `5`                                                              | Default number of search results                    |
 | `SIMILARITY_THRESHOLD` | `0.1`                                                            | Minimum similarity for search results               |
+| `APP_PORT`             | `8000`                                                           | Host port for the application service               |
+| `POSTGRES_PORT`        | `5432`                                                           | Host port for the PostgreSQL service                |
 
 ## Development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_USER: berryrag
       POSTGRES_PASSWORD: berryrag_password
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
@@ -41,7 +41,7 @@ services:
       postgres:
         condition: service_healthy
     ports:
-      - "8000:8000"
+      - "${APP_PORT:-8000}:8000"
 
 volumes:
   postgres_data:

--- a/test_port_config.py
+++ b/test_port_config.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+Test script to verify Docker port configuration works correctly.
+This script checks if the services are accessible on the configured ports.
+"""
+
+import os
+import socket
+import time
+import sys
+from urllib.parse import urlparse
+
+def test_port_connectivity(host, port, service_name):
+    """Test if a port is accessible."""
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(5)
+        result = sock.connect_ex((host, port))
+        sock.close()
+        
+        if result == 0:
+            print(f"✅ {service_name} is accessible on {host}:{port}")
+            return True
+        else:
+            print(f"❌ {service_name} is NOT accessible on {host}:{port}")
+            return False
+    except Exception as e:
+        print(f"❌ Error testing {service_name} on {host}:{port}: {e}")
+        return False
+
+def get_env_port(env_var, default_port):
+    """Get port from environment variable or use default."""
+    try:
+        return int(os.getenv(env_var, default_port))
+    except ValueError:
+        print(f"⚠️  Invalid port value for {env_var}, using default {default_port}")
+        return int(default_port)
+
+def main():
+    print("🔍 Testing Docker Port Configuration")
+    print("=" * 50)
+    
+    # Get configured ports
+    app_port = get_env_port('APP_PORT', 8000)
+    postgres_port = get_env_port('POSTGRES_PORT', 5432)
+    
+    print(f"📋 Configuration:")
+    print(f"   APP_PORT: {app_port}")
+    print(f"   POSTGRES_PORT: {postgres_port}")
+    print()
+    
+    # Test connectivity
+    print("🔌 Testing port connectivity...")
+    
+    app_accessible = test_port_connectivity('localhost', app_port, 'Application')
+    postgres_accessible = test_port_connectivity('localhost', postgres_port, 'PostgreSQL')
+    
+    print()
+    
+    # Summary
+    if app_accessible and postgres_accessible:
+        print("🎉 All services are accessible on configured ports!")
+        print(f"   • Application: http://localhost:{app_port}")
+        print(f"   • PostgreSQL: localhost:{postgres_port}")
+        return 0
+    else:
+        print("⚠️  Some services are not accessible.")
+        print("   Make sure Docker Compose is running with:")
+        print("   docker-compose up")
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Changes Made

### 1. Updated `.env` file
Added port configuration variables:
- `APP_PORT=8084` (your requested app port)
- `POSTGRES_PORT=5435` (your requested PostgreSQL port)

### 2. Modified `docker-compose.yml`
Updated port mappings to use environment variables with fallback defaults:
- PostgreSQL: `"${POSTGRES_PORT:-5432}:5432"`
- Application: `"${APP_PORT:-8000}:8000"`

### 3. Updated `.env.example`
Added commented port configuration examples for other users.

### 4. Enhanced `README_DOCKER.md`
- Added comprehensive "Port Configuration" section
- Documented environment variables in the table
- Provided usage examples for different scenarios
- Included local development instructions with custom ports

### 5. Created `test_port_config.py`
A utility script to verify that services are accessible on configured ports.

## How to Use

With your current `.env` configuration, you can now:

```bash
# Start services with your custom ports
docker-compose up --build

# Access services at:
# - Application: http://localhost:8084
# - PostgreSQL: localhost:5435
```

## Key Benefits

- **Backward Compatible**: Uses default ports (8000, 5432) if environment variables aren't set
- **Flexible**: Easy to change ports without modifying docker-compose.yml
- **Production Ready**: Different environments can use different ports
- **Well Documented**: Clear instructions and examples in README

## Testing

You can verify the port configuration works by running:
```bash
python test_port_config.py
```

The implementation maintains full backward compatibility while providing the flexibility you requested for custom port mappings.